### PR TITLE
Add enterEdge to Bfs and Dfs.

### DIFF
--- a/src/Data/Graph/Algorithm/DepthFirstSearch.hs
+++ b/src/Data/Graph/Algorithm/DepthFirstSearch.hs
@@ -30,17 +30,19 @@ import Data.Graph.Internal.Color
 
 data Dfs g m = Dfs 
   { enterVertex :: Vertex g -> g m -- called the first time a vertex is discovered
+  , enterEdge   :: Edge g   -> g m -- called the first time an edge is discovered, before enterVertex
   , grayTarget  :: Edge g   -> g m -- called when we encounter a back edge to a vertex we're still processing
   , exitVertex  :: Vertex g -> g m -- called once we have processed all descendants of a vertex
   , blackTarget :: Edge g   -> g m -- called when we encounter a cross edge to a vertex we've already finished
   }
 
 instance Graph g => Functor (Dfs g) where
-  fmap f (Dfs a b c d) = Dfs 
+  fmap f (Dfs a b c d e) = Dfs
     (liftM f . a)
     (liftM f . b)
     (liftM f . c)
     (liftM f . d)
+    (liftM f . e)
 
 instance Graph g => Applicative (Dfs g) where
   pure a = Dfs 
@@ -48,9 +50,11 @@ instance Graph g => Applicative (Dfs g) where
     (const (return a))
     (const (return a))
     (const (return a))
+    (const (return a))
 
   m <*> n = Dfs
     (\v -> enterVertex m v `ap` enterVertex n v)
+    (\e -> enterEdge m e `ap`   enterEdge n e)
     (\e -> grayTarget m e `ap`  grayTarget n e)
     (\v -> exitVertex m v `ap`  exitVertex n v)
     (\e -> blackTarget m e `ap` blackTarget n e)
@@ -59,6 +63,7 @@ instance Graph g => Monad (Dfs g) where
   return = pure
   m >>= f = Dfs
     (\v -> enterVertex m v >>= ($ v) . enterVertex . f)
+    (\e -> enterEdge m e >>= ($ e) . enterEdge . f)
     (\e -> grayTarget m e >>= ($ e) . grayTarget . f)
     (\v -> exitVertex m v >>= ($ v) . exitVertex . f)
     (\e -> blackTarget m e >>= ($ e) . blackTarget . f)
@@ -92,7 +97,7 @@ dfs vis v0 = do
         v' <- target e
         color <- getS v'
         liftM (`mappend` m) $ case color of
-          White -> go v'
+          White -> (liftM2 mappend) (lift $ enterEdge vis e) (go v')
           Grey  -> lift $ grayTarget vis e
           Black -> lift $ blackTarget vis e
       ) 


### PR DESCRIPTION
This function notifies the client about the fact that an edge is reached for the first time.

Knowing the edge we use to enter a vertex has important use cases (e.g., when constructing paths (and that's what I'm trying to achieve in my small project)), and I couldn't manage to figure out a simple (~ O(1) ) way of deriving that from the information provided by the four original functions.

While the code is compiling, I am still rather unsure about the validity of some of my changes, and I am particularly unsure about the changes in `bfs` and `dfs`.  Firstly, I'm just appending the result of `enterEdge` to whatever is produced by `enqueue` or `go`, which definitely breaks the seemingly apparent idea of "one monoid element per child".  Less importantly, I'm not sure I've written those two lines sufficiently concisely and clearly.  Therefore I would heartily welcome any suggestions and explanations :-)
