### PR TITLE
Export AdjacencyListGraph and AdjacencyMatrixGraph.

### DIFF
--- a/src/Data/Graph/AdjacencyList.hs
+++ b/src/Data/Graph/AdjacencyList.hs
@@ -13,6 +13,7 @@
 
 module Data.Graph.AdjacencyList
   ( AdjacencyList(..)
+  , AdjacencyListGraph
   , ask
   ) where
 

--- a/src/Data/Graph/AdjacencyMatrix.hs
+++ b/src/Data/Graph/AdjacencyMatrix.hs
@@ -13,6 +13,7 @@
 
 module Data.Graph.AdjacencyMatrix
   ( AdjacencyMatrix(..)
+  , AdjacencyMatrixGraph
   , ask
   ) where
 


### PR DESCRIPTION
These exports are necessary to allow proper type signatures for functions relying on this library.  I have found myself in a weird situation in which I could not write out the type signature for a function using `bfs` because `bfs` requires to be run in the `AdjacencyListGraph` monad, while I could only use the `Graph` monad in type signatures.
