### PR TITLE
Refactor bfs and dfs

### DIFF
--- a/graphs.cabal
+++ b/graphs.cabal
@@ -35,7 +35,7 @@ library
   exposed-modules:
     Data.Graph.AdjacencyList
     Data.Graph.AdjacencyMatrix
-    Data.Graph.Algorithm.Graphsearch
+    Data.Graph.Algorithm.GraphSearch
     Data.Graph.Algorithm.DepthFirstSearch
     Data.Graph.Algorithm.BreadthFirstSearch
     Data.Graph.Class

--- a/graphs.cabal
+++ b/graphs.cabal
@@ -35,6 +35,7 @@ library
   exposed-modules:
     Data.Graph.AdjacencyList
     Data.Graph.AdjacencyMatrix
+    Data.Graph.Algorithm.Graphsearch
     Data.Graph.Algorithm.DepthFirstSearch
     Data.Graph.Algorithm.BreadthFirstSearch
     Data.Graph.Class

--- a/src/Data/Graph/Algorithm/BreadthFirstSearch.hs
+++ b/src/Data/Graph/Algorithm/BreadthFirstSearch.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE TypeFamilies, ViewPatterns #-}
+{-# LANGUAGE TypeFamilies #-}
 -----------------------------------------------------------------------------
 -- |
 -- Module      :  Data.Graph.Algorithm.BreadthFirstSearch
@@ -16,15 +16,15 @@ module Data.Graph.Algorithm.BreadthFirstSearch
   ( bfs
   ) where
 
-import Data.Sequence as S
 import Data.Monoid
+import Data.Sequence
 
 import Data.Graph.Class
 import Data.Graph.Class.AdjacencyList
 import Data.Graph.Algorithm.GraphSearch
 
 -- | Breadth first search visitor
-newtype Queue v = Queue {runQueue :: Seq v}
+newtype Queue v = Queue (Seq v)
 
 instance Monoid (Queue v) where
   mempty = Queue mempty
@@ -32,12 +32,11 @@ instance Monoid (Queue v) where
 
 instance Container (Queue v) where
   type Elem (Queue v) = v
-  emptyC = Queue empty
-  nullC (Queue q) = S.null q
-  getC (viewl . runQueue -> (a :< q)) = (a, Queue q)
-  getC _ = error "Queue is empty"
+
+  getC (Queue q)   = case viewl q of
+                       (a :< q') -> Just (a, Queue q')
+                       _         -> Nothing
   putC v (Queue q) = Queue (q |> v)
-  concatC (Queue q) (Queue q') = Queue (q >< q')
 
 bfs :: (AdjacencyListGraph g, Monoid m) => Queue (Vertex g) -> GraphSearch g m -> Vertex g -> g m
 bfs q vis v0 = graphSearch q vis v0

--- a/src/Data/Graph/Algorithm/BreadthFirstSearch.hs
+++ b/src/Data/Graph/Algorithm/BreadthFirstSearch.hs
@@ -38,5 +38,8 @@ instance Container (Queue v) where
                        _         -> Nothing
   putC v (Queue q) = Queue (q |> v)
 
-bfs :: (AdjacencyListGraph g, Monoid m) => Queue (Vertex g) -> GraphSearch g m -> Vertex g -> g m
-bfs q vis v0 = graphSearch q vis v0
+bfs :: (AdjacencyListGraph g, Monoid m) => GraphSearch g m -> Vertex g -> g m
+bfs vis v0 = bfs' mempty vis v0
+  where
+    bfs' :: (AdjacencyListGraph g, Monoid m) => Queue (Vertex g) -> GraphSearch g m -> Vertex g -> g m
+    bfs' q vis' v0' = graphSearch q vis' v0'

--- a/src/Data/Graph/Algorithm/BreadthFirstSearch.hs
+++ b/src/Data/Graph/Algorithm/BreadthFirstSearch.hs
@@ -31,22 +31,12 @@ import Data.Graph.Internal.Color
 import Data.Graph.Algorithm.GraphSearch
 
 -- | Breadth first search visitor
-bfs :: (AdjacencyListGraph g, Monoid m) => Bfs g m -> Vertex g -> g m
-bfs vis v0 = do
-  m <- vertexMap White
-  evalStateT (enqueue vis v0 >>= pump) (mempty, m)
-  where
-  pump lhs = dequeue (return lhs) $ \ v -> do
-    adjs <- lift $ outEdges v
-    children <- foldrM
-      (\e m -> do
-        v' <- target e
-        color <- getS v'
-        liftM (`mappend` m) $ case color of
-          White -> (liftM2 mappend) (lift $ enterEdge vis e) (enqueue vis v')
-          Grey -> lift $ grayTarget vis e
-          Black -> lift $ blackTarget vis e
-      ) mempty adjs
-    putS v Black
-    rhs <- lift $ exitVertex vis v
-    pump $ lhs `mappend` children `mappend` rhs
+newtype Bfs g m = Bfs (GraphSearch g m)
+
+-- class Graph g => Collection g where
+--   data Container g v :: *
+--   emptyC  :: Container g v
+--   nullC   :: Container g v -> Bool
+--   getC    :: Container g v -> (v, Container g v)
+--   putC    :: v -> Container g v -> Container g v
+--   concatC :: Container g v -> Container g v -> Container g v

--- a/src/Data/Graph/Algorithm/DepthFirstSearch.hs
+++ b/src/Data/Graph/Algorithm/DepthFirstSearch.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE TypeFamilies, ViewPatterns #-}
 -----------------------------------------------------------------------------
 -- |
 -- Module      :  Data.Graph.Algorithm.DepthFirstSearch
@@ -13,96 +13,31 @@
 ----------------------------------------------------------------------------
 
 module Data.Graph.Algorithm.DepthFirstSearch
-  ( dfs, Dfs(..)
+  ( dfs
   ) where
 
-import Control.Applicative
-import Control.Monad
-import Control.Monad.Trans.Class
-import Control.Monad.Trans.State.Strict
-import Data.Foldable
+import Data.Sequence as S
 import Data.Monoid
 
 import Data.Graph.Class
 import Data.Graph.Class.AdjacencyList
-import Data.Graph.PropertyMap
-import Data.Graph.Internal.Color
+import Data.Graph.Algorithm.GraphSearch
 
-data Dfs g m = Dfs
-  { enterVertex :: Vertex g -> g m -- called the first time a vertex is discovered
-  , enterEdge   :: Edge g   -> g m -- called the first time an edge is discovered, before enterVertex
-  , grayTarget  :: Edge g   -> g m -- called when we encounter a back edge to a vertex we're still processing
-  , exitVertex  :: Vertex g -> g m -- called once we have processed all descendants of a vertex
-  , blackTarget :: Edge g   -> g m -- called when we encounter a cross edge to a vertex we've already finished
-  }
+-- | Depth first search visitor
+newtype Stack v = Stack {runStack :: Seq v}
 
-instance Graph g => Functor (Dfs g) where
-  fmap f (Dfs a b c d e) = Dfs
-    (liftM f . a)
-    (liftM f . b)
-    (liftM f . c)
-    (liftM f . d)
-    (liftM f . e)
+instance Monoid (Stack v) where
+  mempty = Stack mempty
+  mappend (Stack q) (Stack q') = Stack (mappend q q')
 
-instance Graph g => Applicative (Dfs g) where
-  pure a = Dfs
-    (const (return a))
-    (const (return a))
-    (const (return a))
-    (const (return a))
-    (const (return a))
+instance Container (Stack v) where
+  type Elem (Stack v) = v
+  emptyC = Stack empty
+  nullC (Stack q) = S.null q
+  getC (viewr . runStack -> (q :> a)) = (a, Stack q)
+  getC _ = error "Stack is empty"
+  putC v (Stack q) = Stack (q |> v)
+  concatC (Stack q) (Stack q') = Stack (q >< q')
 
-  m <*> n = Dfs
-    (\v -> enterVertex m v `ap` enterVertex n v)
-    (\e -> enterEdge m e `ap`   enterEdge n e)
-    (\e -> grayTarget m e `ap`  grayTarget n e)
-    (\v -> exitVertex m v `ap`  exitVertex n v)
-    (\e -> blackTarget m e `ap` blackTarget n e)
-
-instance Graph g => Monad (Dfs g) where
-  return = pure
-  m >>= f = Dfs
-    (\v -> enterVertex m v >>= ($ v) . enterVertex . f)
-    (\e -> enterEdge m e >>= ($ e) . enterEdge . f)
-    (\e -> grayTarget m e >>= ($ e) . grayTarget . f)
-    (\v -> exitVertex m v >>= ($ v) . exitVertex . f)
-    (\e -> blackTarget m e >>= ($ e) . blackTarget . f)
-
-instance (Graph g, Monoid m) => Monoid (Dfs g m) where
-  mempty = return mempty
-  mappend = liftM2 mappend
-
-getS :: Monad g => k -> StateT (PropertyMap g k v) g v
-getS k = do
-  m <- get
-  lift (getP m k)
-
-putS :: Monad g => k -> v -> StateT (PropertyMap g k v) g ()
-putS k v = do
-  m <- get
-  m' <- lift $ putP m k v
-  put m'
-
--- TODO: CPS transform?
-dfs :: (AdjacencyListGraph g, Monoid m) => Dfs g m -> Vertex g -> g m
-dfs vis v0 = do
-  m <- vertexMap White
-  evalStateT (go v0) m where
-  go v = do
-    putS v Grey
-    lhs <- lift $ enterVertex vis v
-    adjs <- lift $ outEdges v
-    result <- foldrM
-      (\e m -> do
-        v' <- target e
-        color <- getS v'
-        liftM (`mappend` m) $ case color of
-          White -> (liftM2 mappend) (lift $ enterEdge vis e) (go v')
-          Grey  -> lift $ grayTarget vis e
-          Black -> lift $ blackTarget vis e
-      )
-      mempty
-      adjs
-    putS v Black
-    rhs <- lift $ exitVertex vis v
-    return $ lhs `mappend` result `mappend` rhs
+dfs :: (AdjacencyListGraph g, Monoid m) => Stack (Vertex g) -> GraphSearch g m -> Vertex g -> g m
+dfs q vis v0 = graphSearch q vis v0

--- a/src/Data/Graph/Algorithm/DepthFirstSearch.hs
+++ b/src/Data/Graph/Algorithm/DepthFirstSearch.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE TypeFamilies, ViewPatterns #-}
+{-# LANGUAGE TypeFamilies #-}
 -----------------------------------------------------------------------------
 -- |
 -- Module      :  Data.Graph.Algorithm.DepthFirstSearch
@@ -16,7 +16,6 @@ module Data.Graph.Algorithm.DepthFirstSearch
   ( dfs
   ) where
 
-import Data.Sequence as S
 import Data.Monoid
 
 import Data.Graph.Class
@@ -24,20 +23,18 @@ import Data.Graph.Class.AdjacencyList
 import Data.Graph.Algorithm.GraphSearch
 
 -- | Depth first search visitor
-newtype Stack v = Stack {runStack :: Seq v}
+newtype Stack v = Stack [v]
 
 instance Monoid (Stack v) where
-  mempty = Stack mempty
-  mappend (Stack q) (Stack q') = Stack (mappend q q')
+  mempty = Stack []
+  mappend (Stack q) (Stack q') = Stack (q ++ q')
 
 instance Container (Stack v) where
   type Elem (Stack v) = v
-  emptyC = Stack empty
-  nullC (Stack q) = S.null q
-  getC (viewr . runStack -> (q :> a)) = (a, Stack q)
-  getC _ = error "Stack is empty"
-  putC v (Stack q) = Stack (q |> v)
-  concatC (Stack q) (Stack q') = Stack (q >< q')
+
+  getC (Stack [])     = Nothing
+  getC (Stack (x:xs)) = Just (x, Stack xs)
+  putC v (Stack q)    = Stack (v : q)
 
 dfs :: (AdjacencyListGraph g, Monoid m) => Stack (Vertex g) -> GraphSearch g m -> Vertex g -> g m
 dfs q vis v0 = graphSearch q vis v0

--- a/src/Data/Graph/Algorithm/DepthFirstSearch.hs
+++ b/src/Data/Graph/Algorithm/DepthFirstSearch.hs
@@ -36,5 +36,8 @@ instance Container (Stack v) where
   getC (Stack (x:xs)) = Just (x, Stack xs)
   putC v (Stack q)    = Stack (v : q)
 
-dfs :: (AdjacencyListGraph g, Monoid m) => Stack (Vertex g) -> GraphSearch g m -> Vertex g -> g m
-dfs q vis v0 = graphSearch q vis v0
+dfs :: (AdjacencyListGraph g, Monoid m) => GraphSearch g m -> Vertex g -> g m
+dfs vis v0 = dfs' mempty vis v0
+  where
+    dfs' :: (AdjacencyListGraph g, Monoid m) => Stack (Vertex g) -> GraphSearch g m -> Vertex g -> g m
+    dfs' q vis' v0' = graphSearch q vis' v0'

--- a/src/Data/Graph/Algorithm/GraphSearch.hs
+++ b/src/Data/Graph/Algorithm/GraphSearch.hs
@@ -75,11 +75,8 @@ instance (Graph g, Monoid m) => Monoid (GraphSearch g m) where
 
 class Container c where
   type Elem c :: *
-  emptyC  :: c
-  nullC   :: c -> Bool
-  getC    :: c -> (Elem c, c)
+  getC    :: c -> Maybe (Elem c, c)
   putC    :: Elem c -> c -> c
-  concatC :: c -> c -> c
 
 getS :: Monad g => k -> StateT (c, PropertyMap g k Color) g Color
 getS k = do
@@ -106,9 +103,7 @@ remove :: (Monad g, Container c)
         => StateT (c, s) g r -> (Elem c -> StateT (c, s) g r) -> StateT (c, s) g r
 remove ke ks = do
   (q, m) <- get
-  if nullC q
-     then ke
-     else let (a, q') = getC q in put (q', m) >> ks a
+  maybe ke (\q' -> put (snd q', m) >> ks (fst q')) (getC q)
 
 graphSearch :: forall g m c. (AdjacencyListGraph g, Monoid m, Container c, Monoid c, Elem c ~ Vertex g)
             => c -> GraphSearch g m -> Vertex g -> g m

--- a/src/Data/Graph/Algorithm/GraphSearch.hs
+++ b/src/Data/Graph/Algorithm/GraphSearch.hs
@@ -55,18 +55,18 @@ instance Graph g => Applicative (GraphSearch g) where
 
   m <*> n = GraphSearch
     (\v -> enterVertex m v `ap` enterVertex n v)
-    (\e -> enterEdge m e `ap`   enterEdge n e)
-    (\e -> grayTarget m e `ap`  grayTarget n e)
-    (\v -> exitVertex m v `ap`  exitVertex n v)
+    (\e -> enterEdge m e   `ap` enterEdge n e)
+    (\e -> grayTarget m e  `ap` grayTarget n e)
+    (\v -> exitVertex m v  `ap` exitVertex n v)
     (\e -> blackTarget m e `ap` blackTarget n e)
 
 instance Graph g => Monad (GraphSearch g) where
   return = pure
   m >>= f = GraphSearch
     (\v -> enterVertex m v >>= ($ v) . enterVertex . f)
-    (\e -> enterEdge m e >>= ($ e) . enterEdge . f)
-    (\e -> grayTarget m e >>= ($ e) . grayTarget . f)
-    (\v -> exitVertex m v >>= ($ v) . exitVertex . f)
+    (\e -> enterEdge m e   >>= ($ e) . enterEdge   . f)
+    (\e -> grayTarget m e  >>= ($ e) . grayTarget  . f)
+    (\v -> exitVertex m v  >>= ($ v) . exitVertex  . f)
     (\e -> blackTarget m e >>= ($ e) . blackTarget . f)
 
 instance (Graph g, Monoid m) => Monoid (GraphSearch g m) where
@@ -75,8 +75,8 @@ instance (Graph g, Monoid m) => Monoid (GraphSearch g m) where
 
 class Container c where
   type Elem c :: *
-  getC    :: c -> Maybe (Elem c, c)
-  putC    :: Elem c -> c -> c
+  getC :: c -> Maybe (Elem c, c)
+  putC :: Elem c -> c -> c
 
 getS :: Monad g => k -> StateT (c, PropertyMap g k Color) g Color
 getS k = do

--- a/src/Data/Graph/Algorithm/GraphSearch.hs
+++ b/src/Data/Graph/Algorithm/GraphSearch.hs
@@ -2,7 +2,7 @@
 -----------------------------------------------------------------------------
 -- |
 -- Module      :  Data.Graph.Algorithm.GraphSearch
--- Copyright   :  (C) 2011-2015 Edvard Kmett, Jeffrey Rosenbluth
+-- Copyright   :  (C) 2011 Edvard Kmett
 -- License     :  BSD-style (see the file LICENSE)
 --
 -- Maintainer  :  Edward Kmett <ekmett@gmail.com>
@@ -110,8 +110,7 @@ remove ke ks = do
      then ke
      else let (a, q') = getC q in put (q', m) >> ks a
 
-graphSearch :: forall g m c.
-              (AdjacencyListGraph g, Monoid m, Container c, Monoid c, Elem c ~ Vertex g)
+graphSearch :: forall g m c. (AdjacencyListGraph g, Monoid m, Container c, Monoid c, Elem c ~ Vertex g)
             => c -> GraphSearch g m -> Vertex g -> g m
 graphSearch _ vis v0 = do
   m <- vertexMap White

--- a/src/Data/Graph/Algorithm/GraphSearch.hs
+++ b/src/Data/Graph/Algorithm/GraphSearch.hs
@@ -1,0 +1,135 @@
+{-# LANGUAGE TypeFamilies #-}
+-----------------------------------------------------------------------------
+-- |
+-- Module      :  Data.Graph.Algorithm.GraphSearch
+-- Copyright   :  (C) 2011-2015 Edvard Kmett, Jeffrey Rosenbluth
+-- License     :  BSD-style (see the file LICENSE)
+--
+-- Maintainer  :  Edward Kmett <ekmett@gmail.com>
+-- Stability   :  experimental
+-- Portability :  type families
+--
+-- Graph search
+----------------------------------------------------------------------------
+
+module Data.Graph.Algorithm.GraphSearch
+  ( graphSearch, GraphSearch(..), Collection(..)
+  ) where
+
+import Control.Applicative
+import Control.Monad
+import Control.Monad.Trans.Class
+import Control.Monad.Trans.State.Strict
+import Data.Foldable
+import Data.Monoid
+
+import Data.Graph.Class
+import Data.Graph.Class.AdjacencyList
+import Data.Graph.PropertyMap
+import Data.Graph.Internal.Color
+
+-- | Graph search visitor
+data GraphSearch g m = GraphSearch
+  { enterVertex :: Vertex g -> g m -- called the first time a vertex is discovered
+  , enterEdge   :: Edge g   -> g m -- called the first time an edge is discovered, before enter
+  , grayTarget  :: Edge g   -> g m -- called when we encounter a back edge to a vertex we're still processing
+  , exitVertex  :: Vertex g -> g m -- called once we have processed all descendants of a vertex
+  , blackTarget :: Edge g   -> g m -- called when we encounter a cross edge to a vertex we've already finished
+  }
+
+instance Graph g => Functor (GraphSearch g) where
+  fmap f (GraphSearch a b c d e) = GraphSearch
+    (liftM f . a)
+    (liftM f . b)
+    (liftM f . c)
+    (liftM f . d)
+    (liftM f . e)
+
+instance Graph g => Applicative (GraphSearch g) where
+  pure a = GraphSearch
+    (const (return a))
+    (const (return a))
+    (const (return a))
+    (const (return a))
+    (const (return a))
+
+  m <*> n = GraphSearch
+    (\v -> enterVertex m v `ap` enterVertex n v)
+    (\e -> enterEdge m e `ap`   enterEdge n e)
+    (\e -> grayTarget m e `ap`  grayTarget n e)
+    (\v -> exitVertex m v `ap`  exitVertex n v)
+    (\e -> blackTarget m e `ap` blackTarget n e)
+
+instance Graph g => Monad (GraphSearch g) where
+  return = pure
+  m >>= f = GraphSearch
+    (\v -> enterVertex m v >>= ($ v) . enterVertex . f)
+    (\e -> enterEdge m e >>= ($ e) . enterEdge . f)
+    (\e -> grayTarget m e >>= ($ e) . grayTarget . f)
+    (\v -> exitVertex m v >>= ($ v) . exitVertex . f)
+    (\e -> blackTarget m e >>= ($ e) . blackTarget . f)
+
+instance (Graph g, Monoid m) => Monoid (GraphSearch g m) where
+  mempty = return mempty
+  mappend = liftM2 mappend
+
+class Graph g => Collection g where
+  data Container g v :: *
+  emptyC  :: Container g v
+  nullC   :: Container g v -> Bool
+  getC    :: Container g v -> (v, Container g v)
+  putC    :: v -> Container g v -> Container g v
+  concatC :: Container g v -> Container g v -> Container g v
+
+instance (Collection g) => Monoid (Container g v) where
+  mempty = emptyC
+  mappend = concatC
+  
+getS :: Monad g => k -> StateT (c, PropertyMap g k Color) g Color
+getS k = do
+  m <- gets snd
+  lift (getP m k)
+
+putS :: Monad g => k -> Color -> StateT (c, PropertyMap g k Color) g ()
+putS k v = do
+  m <- gets snd
+  m' <- lift $ putP m k v
+  modify $ \(q,_) -> (q, m')
+
+insert :: (Graph g, Collection g)
+        => GraphSearch g m
+        -> Vertex g
+        -> StateT (Container g (Vertex g), PropertyMap g (Vertex g) Color) g m
+insert vis v = do
+  m <- gets snd
+  m' <- lift $ putP m v Grey
+  modify $ \(q,_) -> (putC v q, m')
+  lift $ enterVertex vis v
+
+remove :: (Monad g, Collection g)
+        => StateT (Container g v, s) g r -> (v -> StateT (Container g v, s) g r) -> StateT (Container g v, s) g r
+remove ke ks = do
+  (q, m) <- get
+  if nullC q
+     then ke
+     else let (a, q') = getC q in put (q', m) >> ks a
+
+graphSearch :: (AdjacencyListGraph g, Monoid m, Collection g) => GraphSearch g m -> Vertex g -> g m
+graphSearch vis v0 = do
+  m <- vertexMap White
+  evalStateT (insert vis v0 >>= pump) (mempty, m)
+  where
+  pump lhs = remove (return lhs) $ \ v -> do
+    adjs <- lift $ outEdges v
+    children <- foldrM
+      (\e m -> do
+        v' <- target e
+        color <- getS v'
+        liftM (`mappend` m) $ case color of
+          White -> (liftM2 mappend) (lift $ enterEdge vis e) (insert vis v')
+          Grey -> lift $ grayTarget vis e
+          Black -> lift $ blackTarget vis e
+      ) mempty adjs
+    putS v Black
+    rhs <- lift $ exitVertex vis v
+    pump $ lhs `mappend` children `mappend` rhs


### PR DESCRIPTION
I noticed a lot of code duplication in the BreadFirstSearch and DepthFirstSearch module, so I attempted to factor it out into a new module called GraphSearch. After all, the algorithms can be written as to differ only in the data structure used to store the vertices to be visited. This paves the way for easily introducing other graph searches like A*. 

I don't know whether or not you think this is a good idea, or even if it is bug free (although it does compile). After hacking a way a bit I realized I don't really know how to use the library. I would like to run some tests to see if my code works and was wondering if you either had some test code around or point me in the right direction.

thanks
jeff