### PR TITLE
change graphSearch algorithm to accomodate both dfs and bfs

### DIFF
--- a/src/Data/Graph/Algorithm/BreadthFirstSearch.hs
+++ b/src/Data/Graph/Algorithm/BreadthFirstSearch.hs
@@ -33,6 +33,10 @@ instance Monoid (Queue v) where
 instance Container (Queue v) where
   type Elem (Queue v) = v
 
+  peekC (Queue q)  = case viewl q of
+                       (a :< _) -> Just a
+                       _        -> Nothing
+
   getC (Queue q)   = case viewl q of
                        (a :< q') -> Just (a, Queue q')
                        _         -> Nothing

--- a/src/Data/Graph/Algorithm/DepthFirstSearch.hs
+++ b/src/Data/Graph/Algorithm/DepthFirstSearch.hs
@@ -32,9 +32,11 @@ instance Monoid (Stack v) where
 instance Container (Stack v) where
   type Elem (Stack v) = v
 
-  getC (Stack [])     = Nothing
-  getC (Stack (x:xs)) = Just (x, Stack xs)
-  putC v (Stack q)    = Stack (v : q)
+  peekC (Stack [])     = Nothing
+  peekC (Stack (x:_))  = Just x
+  getC  (Stack [])     = Nothing
+  getC  (Stack (x:xs)) = Just (x, Stack xs)
+  putC v (Stack q)     = Stack (v : q)
 
 dfs :: (AdjacencyListGraph g, Monoid m) => GraphSearch g m -> Vertex g -> g m
 dfs vis v0 = dfs' mempty vis v0


### PR DESCRIPTION
Not ready to merge
-------------------------

I think this now works correctly for `enterVertex` and `exitVertex`.
Need to call `enterEdge`, `grayTarget` and `blackTarget`