### PR TITLE
Fix the build on GHC 8.4

### DIFF
--- a/graphs.cabal
+++ b/graphs.cabal
@@ -23,7 +23,7 @@ description:
   > import Data.Graph.AdjacencyList
   > import Data.Graph.Algorithm
   > import Data.Graph.Algorithm.DepthFirstSearch
-  . 
+  .
   create an adjacency list where the vertices are labeled with integers.
   .
   > graph :: Array Int [Int]
@@ -42,13 +42,13 @@ description:
       &#32;&#32;,  exitV  :: [Int]
       &#32;&#32;,  black  :: [(Int, Int)]
       &#32;&#32;&#125;&#32;deriving Show
-    . 
+    .
     instance Monoid Orderings where
       &#32;mempty = Orderings [] [] [] [] []
       &#32;mappend (Orderings a1 a2 a3 a4 a5)(Orderings b1 b2 b3 b4 b5) =
       &#32;&#32;Orderings (a1 ++ b1) (a2 ++ b2) (a3 ++ b3) (a4 ++ b4) (a5 ++ b5)
   @
-  . 
+  .
   The `dfs` function's first argument is of type `GraphSearch` which is
   a visitor containing the functions to be run at various times during the search.
   The second argument is the starting vertex for the search.
@@ -62,7 +62,7 @@ description:
       &#32;&#32;(\v -> return $ mempty &#123;exitV  = [v]&#125;
       &#32;&#32;(\e -> return $ mempty &#123;black  = [e]&#125;
   @
-  .   
+  .
   Finally `runAdjacencylist` unwraps the function in the `Adjacencylist` newtype and runs
   it on `graph`.
   .
@@ -95,6 +95,9 @@ library
     transformers-compat >= 0.3 && < 1,
     containers   >= 0.3     && < 0.6,
     void         >= 0.5.5.1 && < 1
+
+  if !impl(ghc >= 8.0)
+    semigroups   >= 0.16    && < 1
 
   exposed-modules:
     Data.Graph.AdjacencyList

--- a/graphs.cabal
+++ b/graphs.cabal
@@ -97,7 +97,8 @@ library
     void         >= 0.5.5.1 && < 1
 
   if !impl(ghc >= 8.0)
-    semigroups   >= 0.16    && < 1
+    build-depends:
+      semigroups >= 0.16    && < 1
 
   exposed-modules:
     Data.Graph.AdjacencyList

--- a/src/Data/Graph/Algorithm.hs
+++ b/src/Data/Graph/Algorithm.hs
@@ -19,7 +19,10 @@ module Data.Graph.Algorithm
 import Control.Monad
 #if __GLASGOW_HASKELL__ < 710
 import Control.Applicative
-import Data.Monoid
+import Data.Monoid (Monoid(..))
+#endif
+#if !(MIN_VERSION_base(4,11,0))
+import Data.Semigroup (Semigroup(..))
 #endif
 
 import Data.Graph.Class
@@ -65,6 +68,11 @@ instance Graph g => Monad (GraphSearch g) where
     (\v -> exitVertex m v >>= ($ v)  . exitVertex . f)
     (\e -> blackTarget m e >>= ($ e) . blackTarget . f)
 
+instance (Graph g, Semigroup m) => Semigroup (GraphSearch g m) where
+  (<>) = liftM2 (<>)
+
 instance (Graph g, Monoid m) => Monoid (GraphSearch g m) where
   mempty = return mempty
+#if !(MIN_VERSION_base(4,11,0))
   mappend = liftM2 mappend
+#endif


### PR DESCRIPTION
`graphs` needs adapting to the `Semigroup`–`Monoid` proposal.

Originally noticed in https://github.com/ekmett/lens/issues/781#issuecomment-363742861.